### PR TITLE
 feat: reemplazar Alert.alert por modales tematizados #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ backend/src/main/resources/*firebase-adminsdk-*.json
 .DS_Store
 .idea/
 .vscode/
+CLAUDE.md
 

--- a/frontend/components/AppModal.tsx
+++ b/frontend/components/AppModal.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useCallback } from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Info, CheckCircle, XCircle, AlertTriangle } from 'lucide-react-native';
+import {
+    BG_SURFACE, BORDER_LIGHT, TEXT_PRIMARY, TEXT_MUTED,
+    ACCENT_PRIMARY, SUCCESS_BG, DANGER_BORDER, BG_ELEVATED,
+} from '../styles/theme';
+
+export type ModalType = 'info' | 'success' | 'error' | 'warning';
+
+export interface ModalButton {
+    text: string;
+    onPress?: () => void;
+    style?: 'default' | 'cancel' | 'destructive';
+}
+
+export interface ModalConfig {
+    type: ModalType;
+    title: string;
+    message?: string;
+    buttons?: ModalButton[];
+}
+
+interface AppModalProps extends ModalConfig {
+    visible: boolean;
+    onDismiss: () => void;
+}
+
+const ICON_CONFIG = {
+    info:    { Icon: Info,           color: '#60a5fa', bg: '#1e3a5f' },
+    success: { Icon: CheckCircle,    color: '#4ade80', bg: '#14532d' },
+    error:   { Icon: XCircle,        color: '#fca5a5', bg: '#7f1d1d' },
+    warning: { Icon: AlertTriangle,  color: '#fbbf24', bg: '#451a03' },
+};
+
+function getBtnBg(btn: ModalButton): string {
+    if (btn.style === 'destructive') return DANGER_BORDER;
+    if (btn.style === 'cancel')      return BG_ELEVATED;
+    return ACCENT_PRIMARY;
+}
+
+export function AppModal({ visible, onDismiss, type, title, message, buttons }: AppModalProps) {
+    const { Icon, color, bg } = ICON_CONFIG[type];
+    const resolvedButtons: ModalButton[] = buttons?.length ? buttons : [{ text: 'Entendido' }];
+
+    return (
+        <Modal visible={visible} transparent animationType="fade" statusBarTranslucent onRequestClose={onDismiss}>
+            <TouchableOpacity style={sh.overlay} activeOpacity={1} onPress={onDismiss}>
+                <TouchableOpacity activeOpacity={1} style={sh.card} onPress={() => {}}>
+                    <View style={[sh.iconWrap, { backgroundColor: bg }]}>
+                        <Icon size={28} color={color} />
+                    </View>
+                    <Text style={[sh.title, !message && sh.titleNoMsg]}>{title}</Text>
+                    {message ? <Text style={sh.message}>{message}</Text> : null}
+                    <View style={[sh.btnRow, resolvedButtons.length === 1 && sh.btnRowSingle]}>
+                        {resolvedButtons.map((btn, i) => (
+                            <TouchableOpacity
+                                key={i}
+                                style={[sh.btn, { backgroundColor: getBtnBg(btn) }]}
+                                activeOpacity={0.8}
+                                onPress={() => { onDismiss(); btn.onPress?.(); }}
+                            >
+                                <Text style={sh.btnText}>{btn.text}</Text>
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+                </TouchableOpacity>
+            </TouchableOpacity>
+        </Modal>
+    );
+}
+
+export function useAppModal() {
+    const [config, setConfig] = useState<ModalConfig | null>(null);
+    const showModal = useCallback((cfg: ModalConfig) => setConfig(cfg), []);
+    const dismiss   = useCallback(() => setConfig(null), []);
+
+    const modalNode = config ? (
+        <AppModal
+            visible
+            onDismiss={dismiss}
+            type={config.type}
+            title={config.title}
+            message={config.message}
+            buttons={config.buttons}
+        />
+    ) : null;
+
+    return { showModal, modalNode };
+}
+
+const sh = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0,0,0,0.75)',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingHorizontal: 32,
+    },
+    card: {
+        backgroundColor: BG_SURFACE,
+        borderRadius: 24,
+        padding: 28,
+        width: '100%',
+        alignItems: 'center',
+        borderWidth: 1,
+        borderColor: BORDER_LIGHT,
+    },
+    iconWrap: {
+        width: 64,
+        height: 64,
+        borderRadius: 32,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginBottom: 16,
+    },
+    title: {
+        color: TEXT_PRIMARY,
+        fontSize: 18,
+        fontWeight: '700',
+        marginBottom: 8,
+        textAlign: 'center',
+    },
+    titleNoMsg: {
+        marginBottom: 24,
+    },
+    message: {
+        color: TEXT_MUTED,
+        fontSize: 14,
+        textAlign: 'center',
+        marginBottom: 24,
+        lineHeight: 20,
+    },
+    btnRow: {
+        flexDirection: 'row',
+        gap: 12,
+        width: '100%',
+    },
+    btnRowSingle: {
+        justifyContent: 'center',
+    },
+    btn: {
+        flex: 1,
+        paddingVertical: 14,
+        borderRadius: 12,
+        alignItems: 'center',
+    },
+    btnText: {
+        fontSize: 15,
+        fontWeight: '700',
+        color: TEXT_PRIMARY,
+    },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1651,12 +1651,12 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1731,12 +1731,12 @@
       }
     },
     "node_modules/@expo/config/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1871,12 +1871,12 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1898,17 +1898,17 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.12.tgz",
-      "integrity": "sha512-3KguH7kyKqq7pNwLb9j6BBdD/bjmNwXZG/HPWT6GWIXbwrvAJt2JNyYTP5agWJ8jbbuys1yuCzmkX+TU6rmI7A==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.13.tgz",
+      "integrity": "sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.4",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
     },
@@ -2032,12 +2032,12 @@
       }
     },
     "node_modules/@expo/metro-config/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2082,12 +2082,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.3.tgz",
-      "integrity": "sha512-ZuXiK/9fCrIuLjPSe1VYmfp0Sa85kCMwd8QQpgyi5ufppYKRtLBg14QOgUqj8ZMbJTxE0xqzd0XR7kOs3vAK9A==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.10.4.tgz",
+      "integrity": "sha512-y9Mr4Kmpk4abAVZrNNPCdzOZr8nLLyi18p1SXr0RCVA8IfzqZX/eY4H+50a0HTmXqIsPZrQdcdb4I3ekMS9GvQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.0.12",
+        "@expo/json-file": "^10.0.13",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2106,11 +2106,43 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/@expo/prebuild-config": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
+      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.8",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@expo/require-utils": {
       "version": "55.0.4",
       "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
       "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2174,9 +2206,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.1.tgz",
-      "integrity": "sha512-KZNxZvnGCtiM2aYYZ6Wz0Ix5r47dAvpNLApFtZWnSoERzAdOMzVBOPysBoM0JlF6FKWZ8GPqgn6qt3dV/8Zlpg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.3.tgz",
+      "integrity": "sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2185,6 +2217,24 @@
       },
       "bin": {
         "excpretty": "build/cli.js"
+      }
+    },
+    "node_modules/@expo/xcpretty/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@expo/xcpretty/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -2224,32 +2274,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3033,41 +3061,18 @@
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
     },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.81.5",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
-      "integrity": "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 20.19.4"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.1.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-navigation/bottom-tabs": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.8.tgz",
-      "integrity": "sha512-Fz/AAPE6Be0CimOXvon75RNgpFCbZvzF2RPcNeZOdOxIYyHDGxDdtsfTxLHB0tOp9HHXkT0xXOX8Rk001jdpbg==",
+      "version": "7.15.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.9.tgz",
+      "integrity": "sha512-Ou28A1aZLj5wiFQ3F93aIsrI4NCwn3IJzkkjNo9KLFXsc0Yks+UqrVaFlffHFLsrbajuGRG/OQpnMA1ljayY5Q==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.13",
+        "@react-navigation/elements": "^2.9.14",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.2.1",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -3075,9 +3080,9 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.1.tgz",
-      "integrity": "sha512-P1kL4FVTVYEf9Cvmb+WFxQ2UkbaXc9psj6OE0BsZ+hutPqZVbmiN6v/TI5QPf4qtg40a02yYo3vo+Mob9vJKtg==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.2.tgz",
+      "integrity": "sha512-Rt2OZwcgOmjv401uLGAKaRM6xo0fiBce/A7LfRHI1oe5FV+KooWcgAoZ2XOtgKj6UzVMuQWt3b2e6rxo/mDJRA==",
       "license": "MIT",
       "dependencies": {
         "@react-navigation/routers": "^7.5.3",
@@ -3094,9 +3099,9 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.13.tgz",
-      "integrity": "sha512-ZD8fPwhujgs3SwgaPRse+shLCFkeLhlfk9BHtQ604Qa7/p0/sRQV9HkTfREP8gtbt6nwk6WE+0vWfX2iqxOCKA==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
+      "integrity": "sha512-lKqzu+su2pI/YIZmR7L7xdOs4UL+rVXKJAMpRMBrwInEy96SjIFst6QDGpE89Dunnu3VjVpjWfByo9f2GWBHDQ==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -3105,7 +3110,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.2.1",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -3117,13 +3122,13 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.1.tgz",
-      "integrity": "sha512-ohiGfR5kX585aADiYt+nfwdqmJjj5W/1eXN9CQ/njhQNi/sMmjaxYppS+e0E0zW+z5b4gaLFBvqLrJcvOdtLUA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
+      "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-navigation/core": "^7.17.1",
+        "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
@@ -3135,18 +3140,18 @@
       }
     },
     "node_modules/@react-navigation/native-stack": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.9.tgz",
-      "integrity": "sha512-s76NyRr/VSPRqXaLtaKUj9Q1qZ5ym0831QZFFXJcRyom6QYpo9eESB9/dfeN+tTEnH7kP77CwoCuR0THKMuk3w==",
+      "version": "7.14.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.11.tgz",
+      "integrity": "sha512-1ufBtJ7KbVFlQhXsYSYHqjgkmP30AzJSgW48YjWMQZ3NZGAyYe34w9Wd4KpdebQCfDClPe9maU+8crA/awa6lQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/elements": "^2.9.13",
+        "@react-navigation/elements": "^2.9.14",
         "color": "^4.2.3",
         "sf-symbols-typescript": "^2.1.0",
         "warn-once": "^0.1.1"
       },
       "peerDependencies": {
-        "@react-navigation/native": "^7.2.1",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0",
@@ -3314,12 +3319,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -3555,18 +3560,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3574,10 +3567,13 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -3890,9 +3886,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3955,9 +3951,9 @@
       }
     },
     "node_modules/bplist-parser": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
-      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -3967,9 +3963,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3988,9 +3984,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4008,11 +4004,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4083,14 +4079,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -4149,9 +4145,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4954,9 +4950,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -5845,27 +5841,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
-      "integrity": "sha512-EA7N4dloty2t5Rde+HP0IEE+nkAQiu4A/+QGZGT9mFnZ5KKjPPkqSyYcRvP5bhQE10D+tvz6X0ngZpulbMdbsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
-        "@expo/config-types": "^54.0.10",
-        "@expo/image-utils": "^0.8.8",
-        "@expo/json-file": "^10.0.8",
-        "@react-native/normalize-colors": "0.81.5",
-        "debug": "^4.3.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "xml2js": "0.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5905,18 +5880,30 @@
       }
     },
     "node_modules/expo/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo/node_modules/picomatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/expo/node_modules/react-refresh": {
@@ -5938,6 +5925,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -5965,23 +5962,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/filelist": {
@@ -6291,9 +6271,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6379,9 +6359,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7560,17 +7540,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
@@ -7665,18 +7634,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jest-validate": {
@@ -7901,12 +7858,13 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -8921,18 +8879,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -8946,9 +8892,9 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8962,15 +8908,6 @@
       "dependencies": {
         "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9125,9 +9062,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -9550,9 +9487,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -9565,12 +9502,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -10047,9 +9984,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -10121,9 +10058,9 @@
       }
     },
     "node_modules/react-native-nitro-modules": {
-      "version": "0.35.4",
-      "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.4.tgz",
-      "integrity": "sha512-4qZa+1kgR/sPRNZv+UShxyArEPpovWxw76Dfd/DtCVtkQ92wOOxGIzdYvndprabd+t+r8zNYgYEPYE74gzkuVQ==",
+      "version": "0.35.5",
+      "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.5.tgz",
+      "integrity": "sha512-aa03UzC5dLg5qFfyBkVK+JGSwHTjmK7jUZzyRz11r1Yk9C/nJTFe59EeHPxxNNTagkiwQTM6p3sySgD/TDRC7Q==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -10162,9 +10099,9 @@
       }
     },
     "node_modules/react-native-quick-crypto": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.0.18.tgz",
-      "integrity": "sha512-VjBLW2PasOUSxAqy2IDNvLqBez9NwTDBecwCpuz0F5WkzPDGZ4CuZEFGyL1qfkjwok11F0x3IyMrmCyFBAtOCQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.0.19.tgz",
+      "integrity": "sha512-aIWUVEhGQq0Occ8mDkABqNpg5/nZFYHrpvjWDrSUHE1huAnGDxMqlLP3NM8axma/dWiG/1Tf+Ckb4gllB5LMlQ==",
       "license": "MIT",
       "dependencies": {
         "@craftzdog/react-native-buffer": "6.1.0",
@@ -10232,6 +10169,29 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
+      "integrity": "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.1.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -10445,9 +10405,9 @@
       "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
@@ -10510,11 +10470,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -10899,18 +10860,6 @@
         "plist": "^3.0.5"
       }
     },
-    "node_modules/simple-plist/node_modules/bplist-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
-      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "1.6.x"
-      },
-      "engines": {
-        "node": ">= 5.10.0"
-      }
-    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -10942,9 +10891,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.8.tgz",
-      "integrity": "sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -10969,9 +10918,10 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11329,9 +11279,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -11352,6 +11302,16 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -11367,9 +11327,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11423,13 +11383,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11438,11 +11398,29 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11605,7 +11583,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -11617,18 +11595,18 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/frontend/screens/login/HomeScreen.tsx
+++ b/frontend/screens/login/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { View, Image, TouchableOpacity, Text, Animated, StyleSheet, Dimensions, Easing, Alert, ActivityIndicator } from 'react-native';
+import { View, Image, TouchableOpacity, Text, Animated, StyleSheet, Dimensions, Easing, ActivityIndicator } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import QuickCrypto from 'react-native-quick-crypto';
 import ShimmerText from './ShimmerText';
 import LoadingScreen from './LoadingScreen';
@@ -21,6 +22,7 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
     const [isLoading, setIsLoading] = useState(false);
     const [isRestoring, setIsRestoring] = useState(false);
     const [loginLoading, setLoginLoading] = useState(false);
+    const { showModal, modalNode } = useAppModal();
 
     const bootstrapPromiseRef = useRef<Promise<LoginFlowResult> | null>(null);
     const pinRef = useRef<string>('');
@@ -56,20 +58,21 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
     };
 
     const handleRestoreClick = () => {
-        Alert.alert(
-            'Restaurar Identidad',
-            'Aquí se abrirá el explorador de archivos para seleccionar tu Bóveda de Respaldo (.hnet). Tras seleccionarlo, te pediremos tu contraseña de cifrado.',
-            [
+        showModal({
+            type: 'warning',
+            title: 'Restaurar Identidad',
+            message: 'Aquí se abrirá el explorador de archivos para seleccionar tu Bóveda de Respaldo (.hnet). Tras seleccionarlo, te pediremos tu contraseña de cifrado.',
+            buttons: [
                 { text: 'Cancelar', style: 'cancel' },
                 {
                     text: 'Simular Selección',
                     onPress: () => {
                         setIsRestoring(true);
                         animateToPinScreen();
-                    }
-                }
-            ]
-        );
+                    },
+                },
+            ],
+        });
     };
 
     const handlePinComplete = (pin: string) => {
@@ -88,15 +91,16 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
             await authStoreLogin(result.identity, result.jwtToken);
             if (onAuthSuccess) onAuthSuccess();
         } catch {
-            Alert.alert(
-                'Error de conexión',
-                'No se pudo conectar al servidor. ¿Reintentar?',
-                [
+            showModal({
+                type: 'error',
+                title: 'Error de conexión',
+                message: 'No se pudo conectar al servidor. ¿Reintentar?',
+                buttons: [
                     {
                         text: 'Reintentar',
                         onPress: () => {
                             bootstrapPromiseRef.current = authFlowService.bootstrapLogin();
-                        }
+                        },
                     },
                     {
                         text: 'Cancelar',
@@ -104,12 +108,12 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
                         onPress: () => {
                             Animated.timing(slideLoadingAnim, { toValue: height, duration: 300, useNativeDriver: true })
                                 .start(() => setIsLoading(false));
-                        }
+                        },
                     },
-                ]
-            );
+                ],
+            });
         }
-    }, [authStoreLogin, onAuthSuccess, slideLoadingAnim]);
+    }, [authStoreLogin, onAuthSuccess, showModal, slideLoadingAnim]);
 
     const handleLoginComplete = useCallback(async (pin: string) => {
         setLoginLoading(true);
@@ -125,18 +129,18 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
             ]);
             if (cachedIdentity && cachedJwt && storedHash) {
                 if (hashPin(pin, cachedIdentity.id) !== storedHash) {
-                    Alert.alert('PIN incorrecto', 'No se pudo acceder a tu bóveda local.');
+                    showModal({ type: 'error', title: 'PIN incorrecto', message: 'No se pudo acceder a tu bóveda local.' });
                     return;
                 }
                 await authStoreLogin(cachedIdentity, cachedJwt);
                 if (onAuthSuccess) onAuthSuccess();
             } else {
-                Alert.alert('Error de autenticación', 'No se pudo verificar tu identidad. Comprueba la conexión.');
+                showModal({ type: 'error', title: 'Error de autenticación', message: 'No se pudo verificar tu identidad. Comprueba la conexión.' });
             }
         } finally {
             setLoginLoading(false);
         }
-    }, [authStoreLogin, onAuthSuccess]);
+    }, [authStoreLogin, onAuthSuccess, showModal]);
 
     if (hasAccount === null) {
         return <View style={{ flex: 1, backgroundColor: '#0d111b' }} />;
@@ -227,6 +231,7 @@ export default function HomeScreen({ onAuthSuccess }: { onAuthSuccess?: () => vo
                     <Text style={{ color: '#a0aec0', marginTop: 12, fontSize: 14 }}>Autenticando...</Text>
                 </View>
             )}
+            {modalNode}
         </View>
     );
 }

--- a/frontend/screens/main/ChatRoomScreen.tsx
+++ b/frontend/screens/main/ChatRoomScreen.tsx
@@ -2,8 +2,9 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import {
     View, Text, TextInput, TouchableOpacity, Modal, ScrollView,
     KeyboardAvoidingView, Platform, Dimensions, Animated, PanResponder,
-    StatusBar, Alert,
+    StatusBar,
 } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { X, ChevronsDown, ArrowLeft, User, CornerUpLeft, Send } from 'lucide-react-native';
 import { styles, sh } from '../../styles/chatRoomStyles';
 import { messageFlowService } from '../../services/MessageFlowService';
@@ -315,6 +316,7 @@ export default function ChatRoomScreen({ onBack, chatId }: { onBack: () => void;
     const [isSending, setIsSending] = useState(false);
     const [contactName, setContactName] = useState<string>(chatId.slice(5, 17));
     const { fontScale, prefs: { highContrast } } = useAccessibility();
+    const { showModal, modalNode } = useAppModal();
 
     const allMessagesRef = useRef(allMessages);
     const scrollPxAnim = useRef(new Animated.Value(0)).current;
@@ -392,7 +394,7 @@ export default function ChatRoomScreen({ onBack, chatId }: { onBack: () => void;
 
         setIsSending(true);
         messageFlowService.sendMessage({ recipientId: chatId, plaintext: text })
-            .catch(() => Alert.alert('Error al enviar', 'El mensaje no se pudo entregar.'))
+            .catch(() => showModal({ type: 'error', title: 'Error al enviar', message: 'El mensaje no se pudo entregar.' }))
             .finally(() => setIsSending(false));
     }, [newMessage, replyingTo, scrollPxAnim, chatId, isSending]);
 
@@ -464,6 +466,7 @@ export default function ChatRoomScreen({ onBack, chatId }: { onBack: () => void;
                 />
 
                 <FullMessageModal msg={fullTextMsg} contactName={contactName} onClose={closeModal} />
+                {modalNode}
 
             </View>
         </KeyboardAvoidingView>

--- a/frontend/screens/main/ChatsScreen.tsx
+++ b/frontend/screens/main/ChatsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { View, Text, TextInput, TouchableOpacity, FlatList, Image, KeyboardAvoidingView, Platform, StatusBar, Animated, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, FlatList, Image, KeyboardAvoidingView, Platform, StatusBar, Animated, StyleSheet, ActivityIndicator } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { User, Lock, Search, Settings, QrCode, ScanLine } from 'lucide-react-native';
 import { styles } from '../../styles/chatsStyles';
@@ -35,6 +36,7 @@ export default function ChatsScreen() {
     const { identity } = useAuthStore();
     const networkStatus = useNetworkStatus();
     const { fontScale } = useAccessibility();
+    const { showModal, modalNode } = useAppModal();
     const insets = useSafeAreaInsets();
 
     const chatSlide     = useSlideAnim();
@@ -109,17 +111,17 @@ export default function ChatsScreen() {
     const handleScannedQR = useCallback(async (data: string) => {
         try {
             if (identity && data.includes(identity.id)) {
-                Alert.alert('QR no válido', 'No puedes añadirte a ti mismo como contacto.');
+                showModal({ type: 'warning', title: 'QR no válido', message: 'No puedes añadirte a ti mismo como contacto.' });
                 handleCloseQR();
                 return;
             }
             const contact = await contactsService.saveContactFromQR(data);
             await refreshContacts();
             handleCloseQR();
-            Alert.alert('Contacto añadido', `${contact.contactHash} se guardó correctamente.`);
+            showModal({ type: 'success', title: 'Contacto añadido', message: `${contact.contactHash} se guardó correctamente.` });
         } catch (err: any) {
             handleCloseQR();
-            Alert.alert('Error', err?.message ?? 'No se pudo añadir el contacto.');
+            showModal({ type: 'error', title: 'Error', message: err?.message ?? 'No se pudo añadir el contacto.' });
         }
     }, [identity, handleCloseQR, refreshContacts]);
 
@@ -307,6 +309,7 @@ export default function ChatsScreen() {
             >
                 {showShowQR && <ShowQRScreen onClose={handleCloseShowQR} />}
             </Animated.View>
+            {modalNode}
         </KeyboardAvoidingView>
     );
 }

--- a/frontend/screens/main/QRScannerScreen.tsx
+++ b/frontend/screens/main/QRScannerScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef } from 'react';
 import {
     View, Text, TouchableOpacity, StyleSheet,
-    StatusBar, Alert, Dimensions, Animated,
+    StatusBar, Dimensions, Animated,
 } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { X, ScanLine, FlashlightOff, Flashlight } from 'lucide-react-native';
 import { sh, FRAME_SIZE } from '../../styles/qrScannerStyles';
@@ -20,6 +21,7 @@ export default function QRScannerScreen({ onClose, onScanned }: Props) {
     const [scanned, setScanned] = useState(false);
     const [torch, setTorch] = useState(false);
     const scanLineAnim = useRef(new Animated.Value(0)).current;
+    const { showModal, modalNode } = useAppModal();
 
     // Animate scan line looping
     React.useEffect(() => {
@@ -52,14 +54,15 @@ export default function QRScannerScreen({ onClose, onScanned }: Props) {
         if (onScanned) {
             onScanned(data);
         } else {
-            Alert.alert(
-                'QR Escaneado',
-                `Hash ID: ${data}`,
-                [
+            showModal({
+                type: 'info',
+                title: 'QR Escaneado',
+                message: `Hash ID: ${data}`,
+                buttons: [
                     { text: 'Escanear otro', onPress: () => setScanned(false) },
-                    { text: 'Cerrar', onPress: onClose },
-                ]
-            );
+                    { text: 'Cerrar', style: 'cancel', onPress: onClose },
+                ],
+            });
         }
     };
 
@@ -160,6 +163,7 @@ export default function QRScannerScreen({ onClose, onScanned }: Props) {
                     </TouchableOpacity>
                 )}
             </View>
+            {modalNode}
         </View>
     );
 }

--- a/frontend/screens/settings/PrivacyScreen.tsx
+++ b/frontend/screens/settings/PrivacyScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StatusBar, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, StatusBar } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { ArrowLeft, ShieldCheck, Eye, Database, Trash2 } from 'lucide-react-native';
 import { styles } from '../../styles/settingsStyles';
 import { databaseService } from '../../services/DatabaseService';
@@ -10,12 +11,14 @@ interface Props {
 
 // ── PrivacyScreen ──────────────────────────────────────────────────────────────
 export default function PrivacyScreen({ onBack }: Props) {
+    const { showModal, modalNode } = useAppModal();
 
     const handleClearHistory = () => {
-        Alert.alert(
-            'Borrar historial',
-            'Se eliminarán todos los mensajes guardados en este dispositivo. Esta acción no se puede deshacer.',
-            [
+        showModal({
+            type: 'warning',
+            title: 'Borrar historial',
+            message: 'Se eliminarán todos los mensajes guardados en este dispositivo. Esta acción no se puede deshacer.',
+            buttons: [
                 { text: 'Cancelar', style: 'cancel' },
                 {
                     text: 'Borrar',
@@ -23,14 +26,14 @@ export default function PrivacyScreen({ onBack }: Props) {
                     onPress: async () => {
                         try {
                             await databaseService.clearAllData();
-                            Alert.alert('Hecho', 'El historial local ha sido eliminado.');
+                            showModal({ type: 'success', title: 'Hecho', message: 'El historial local ha sido eliminado.' });
                         } catch {
-                            Alert.alert('Error', 'No se pudo borrar el historial.');
+                            showModal({ type: 'error', title: 'Error', message: 'No se pudo borrar el historial.' });
                         }
                     },
                 },
-            ]
-        );
+            ],
+        });
     };
 
     return (
@@ -96,6 +99,7 @@ export default function PrivacyScreen({ onBack }: Props) {
                 </TouchableOpacity>
 
             </ScrollView>
+            {modalNode}
         </View>
     );
 }

--- a/frontend/screens/settings/SecurityScreen.tsx
+++ b/frontend/screens/settings/SecurityScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, Switch, StatusBar, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, Switch, StatusBar } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { ArrowLeft, Fingerprint, Users } from 'lucide-react-native';
 // expo-local-authentication requiere un development build; en Expo Go se degrada sin biometría
 let LocalAuthentication: typeof import('expo-local-authentication') | null = null;
@@ -60,6 +61,7 @@ export default function SecurityScreen({ onBack }: Props) {
     const [prefs, setPrefs] = useState<SecurityPrefs>({ biometric: false, screenLock: false });
     const [biometricAvailable, setBiometricAvailable] = useState(false);
     const [loading, setLoading] = useState(true);
+    const { showModal, modalNode } = useAppModal();
 
     useEffect(() => {
         const init = async () => {
@@ -95,7 +97,7 @@ export default function SecurityScreen({ onBack }: Props) {
             return;
         }
         if (!LocalAuthentication) {
-            Alert.alert('No disponible', 'La biometría requiere un build nativo de la app.');
+            showModal({ type: 'info', title: 'No disponible', message: 'La biometría requiere un build nativo de la app.' });
             return;
         }
         const result = await LocalAuthentication.authenticateAsync({
@@ -105,7 +107,7 @@ export default function SecurityScreen({ onBack }: Props) {
         if (result.success) {
             await updatePrefs({ ...prefs, biometric: true, screenLock: true });
         } else {
-            Alert.alert('No autenticado', 'La biometría no se activó.');
+            showModal({ type: 'error', title: 'No autenticado', message: 'La biometría no se activó.' });
         }
     };
 
@@ -181,6 +183,7 @@ export default function SecurityScreen({ onBack }: Props) {
                     </View>
                 </View>
             </ScrollView>
+            {modalNode}
         </View>
     );
 }

--- a/frontend/screens/settings/SettingsScreen.tsx
+++ b/frontend/screens/settings/SettingsScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import {
     View, Text, TouchableOpacity, ScrollView, Modal,
-    KeyboardAvoidingView, Platform, Alert, Animated, StyleSheet,
+    KeyboardAvoidingView, Platform, Animated, StyleSheet,
 } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import {
     ArrowLeft, User, Bell, Shield, HelpCircle, FileText,
     Download, LogOut, Trash2, ChevronRight,
@@ -56,6 +57,7 @@ const SettingRow = React.memo(function SettingRow({
 export default function SettingsScreen({ onBack }: Props) {
     const [confirmModal, setConfirmModal] = useState<ConfirmModal>(null);
     const [activeSub, setActiveSub] = useState<SubScreen>(null);
+    const { showModal, modalNode } = useAppModal();
     const subSlide = useSlideAnim(300);
     const identity = useAuthStore((s) => s.identity);
     const storeLogout = useAuthStore((s) => s.logout);
@@ -72,7 +74,7 @@ export default function SettingsScreen({ onBack }: Props) {
 
     const handleCopyId = async () => {
         await Clipboard.setStringAsync(hashId);
-        Alert.alert('Copiado', 'Tu Hash ID fue copiado al portapapeles.');
+        showModal({ type: 'success', title: 'Copiado', message: 'Tu Hash ID fue copiado al portapapeles.' });
     };
 
     const confirmLogout = async () => {
@@ -298,6 +300,8 @@ export default function SettingsScreen({ onBack }: Props) {
                     </TouchableOpacity>
                 </TouchableOpacity>
             </Modal>
+
+            {modalNode}
 
             {/* ── Sub-screen slide overlay ── */}
             <Animated.View

--- a/frontend/screens/settings/TransferScreen.tsx
+++ b/frontend/screens/settings/TransferScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, StatusBar, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, StatusBar } from 'react-native';
+import { useAppModal } from '../../components/AppModal';
 import { ArrowLeft, Download, Upload, ShieldCheck } from 'lucide-react-native';
 import { styles } from '../../styles/settingsStyles';
 
@@ -9,14 +10,16 @@ interface Props {
 
 // ── TransferScreen ─────────────────────────────────────────────────────────────
 export default function TransferScreen({ onBack }: Props) {
+    const { showModal, modalNode } = useAppModal();
+
     const handleExport = () => {
         // TODO: generate and share encrypted .hnet backup file
-        Alert.alert('Exportar respaldo', 'Funcionalidad próximamente disponible.');
+        showModal({ type: 'info', title: 'Exportar respaldo', message: 'Funcionalidad próximamente disponible.' });
     };
 
     const handleImport = () => {
         // TODO: pick file and restore from .hnet backup
-        Alert.alert('Importar respaldo', 'Funcionalidad próximamente disponible.');
+        showModal({ type: 'info', title: 'Importar respaldo', message: 'Funcionalidad próximamente disponible.' });
     };
 
     return (
@@ -56,6 +59,7 @@ export default function TransferScreen({ onBack }: Props) {
                     </View>
                 </View>
             </ScrollView>
+            {modalNode}
         </View>
     );
 }


### PR DESCRIPTION
Crea AppModal (components/AppModal.tsx) con hook useAppModal(), con variantes info/success/error/warning que respetan el tema oscuro de la app. Sustituye las 15 llamadas a Alert.alert en HomeScreen, ChatRoomScreen, QRScannerScreen, ChatsScreen, SettingsScreen, PrivacyScreen, SecurityScreen y TransferScreen.